### PR TITLE
Handling unconventional pods

### DIFF
--- a/src/solid/routes.js
+++ b/src/solid/routes.js
@@ -251,7 +251,9 @@ export async function getRouteFromPod(fileName, userWebId) {
       console.log("[ERROR] Skipped reading a wrong route: " + fileName);
       return null;
     }
-}}
+  }
+  return null;
+}
 
 /**
  * Returns an array containing the routes in a given user's pod.

--- a/src/solid/routes.js
+++ b/src/solid/routes.js
@@ -251,8 +251,7 @@ export async function getRouteFromPod(fileName, userWebId) {
       console.log("[ERROR] Skipped reading a wrong route: " + fileName);
       return null;
     }
-  return null;
-}
+}}
 
 /**
  * Returns an array containing the routes in a given user's pod.
@@ -410,9 +409,13 @@ export async function checkInboxForSharedRoutes(userWebId) {
   for (i; i < folder.files.length; i++) {
     if(!folder.files[i].url.includes(".acl")){
       let notification = await fc.readFile(folder.files[i].url);
-      let routeUri = getRouteUriFromShareNotification(JSON.parse(notification));
-      await addRouteUriToShared(userWebId, routeUri);
-      await fc.deleteFile(folder.files[i].url);
+      try{
+        let routeUri = getRouteUriFromShareNotification(JSON.parse(notification));
+        await addRouteUriToShared(userWebId, routeUri);
+        await fc.deleteFile(folder.files[i].url);
+      } catch{
+        console.log("Please, be polite and don´t try to make our app crash.")
+      }
     }
   }
 }

--- a/src/solid/routes.js
+++ b/src/solid/routes.js
@@ -129,7 +129,7 @@ async function getRouteObjectFromPodRoute(route, routeFilename) {
       sharedWith: [],
     };
   } catch {
-    console.log("[ERROR] Route does not follow the specification: " + routeFilename.
+    console.log("[ERROR] Route does not follow the specification: " + routeFilename);
   }
 }
 
@@ -248,7 +248,7 @@ export async function getRouteFromPod(fileName, userWebId) {
       let podRoute = await readToJson(url + fileName);
       return getRouteObjectFromPodRoute(podRoute, fileName);
     } catch {
-      console.log("Skipped reading a wrong route: " + fileName);
+      console.log("[ERROR] Skipped reading a wrong route: " + fileName);
       return null;
     }
   return null;

--- a/src/solid/routes.js
+++ b/src/solid/routes.js
@@ -556,8 +556,12 @@ export async function getNotifications(userWebId) {
 
   let i = 0;
   for (i; i < notificationFiles.length; i++) {
-    let notification = await getNotification(fc, notificationFiles[i]);
-    notifications.push(notification);
+    try {
+      let notification = await getNotification(fc, notificationFiles[i]);
+      notifications.push(notification);
+    } catch {
+      console.log("Please be polite and don´t try to make our app crash");
+    }
   }
 
   return notifications;

--- a/src/solid/routes.js
+++ b/src/solid/routes.js
@@ -285,21 +285,25 @@ export async function getRoutesFromPod(userWebId) {
       let file = await readToJson(sharedFiles[i].url);
       if (file !== null) {
         let routesUris = file.routes;
-        // All routes uris of a file (of a friend)
-        routesUris = routesUris.map((route) => route["@id"]);
-        let routeObjects = routesUris.map(async (route) => {
-          let parsed = JSON.parse(await fc.readFile(route));
-          let fileName = route.split("/");
-          fileName = fileName[fileName.length - 1];
-          let object = await getRouteObjectFromPodRoute(
-            parsed,
-            fileName
+        try {
+          // All routes uris of a file (of a friend)
+          routesUris = routesUris.map((route) => route["@id"]);
+          let routeObjects = routesUris.map(async (route) => {
+            let parsed = JSON.parse(await fc.readFile(route));
+            let fileName = route.split("/");
+            fileName = fileName[fileName.length - 1];
+            let object = await getRouteObjectFromPodRoute(
+              parsed,
+              fileName
+            );
+            return object;
+          });
+          await Promise.all(routeObjects).then((objects) =>
+            objects.map((object) => routes.push(object))
           );
-          return object;
-        });
-        await Promise.all(routeObjects).then((objects) =>
-          objects.map((object) => routes.push(object))
-        );
+        } catch {
+          console.log("[ERROR] Some shared route was wrong.");
+        }
       }
     }
   }

--- a/src/solid/tests/routes.test.js
+++ b/src/solid/tests/routes.test.js
@@ -335,8 +335,9 @@ describe("Solid Routes", () => {
         // Recreate friend inbox folder
         if (await fc.itemExists(solid.getInboxFolder(friendWebId))) {
             await fc.deleteFolder(solid.getInboxFolder(friendWebId));
-            await fc.createFolder(solid.getInboxFolder(friendWebId));
         }
+
+      await solid.createFolderIfAbsent(solid.getInboxFolder(friendWebId));
 
         // Upload route and get its uri
         await solid.uploadRouteToPod(firstRoute, userWebId);


### PR DESCRIPTION
I made so routes in the user's folder are checked to be .jsonld files and that if any of then can't be read or causes an error when transforming to our json object the route is ignored. I also made so the sharedRoutes file is ignored if it is wrong, and that if some of its urls is wrong it is also ignored.

I added `console.log()` calls to show the errors, since I think they are justified here and it can help if something is wrong during the presentation. If would prefer for them to "fail" silently we could talk about it.

Maybe more checks in other places should be added, I leave the PR here for the moment for visibility.